### PR TITLE
Set up single table inheritance for contents

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,0 +1,2 @@
+class Article < Content
+end

--- a/app/models/audio.rb
+++ b/app/models/audio.rb
@@ -1,0 +1,2 @@
+class Audio < Content
+end

--- a/app/models/content.rb
+++ b/app/models/content.rb
@@ -4,5 +4,5 @@ class Content < ApplicationRecord
   validates :title, presence: true
   # validates :format, presence: true, inclusion: { in: %w[.txt .mp3 .mpg4],
   #                                                 message: "this is not a valid format" }
-  enum category: [:video, :photo, :article, :audio]
+  enum type: [:video, :photo, :article, :audio]
 end

--- a/app/models/content.rb
+++ b/app/models/content.rb
@@ -4,5 +4,5 @@ class Content < ApplicationRecord
   validates :title, presence: true
   # validates :format, presence: true, inclusion: { in: %w[.txt .mp3 .mpg4],
   #                                                 message: "this is not a valid format" }
-  enum type: [:video, :photo, :article, :audio]
+  # enum type: [:video, :photo, :article, :audio]
 end

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -1,0 +1,2 @@
+class Photo < Content
+end

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -1,0 +1,2 @@
+class Video < Content
+end

--- a/db/migrate/20210311124715_change_category_to_type_in_contents.rb
+++ b/db/migrate/20210311124715_change_category_to_type_in_contents.rb
@@ -1,0 +1,6 @@
+class ChangeCategoryToTypeInContents < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :contents, :category
+    add_column :contents, :type, :integer
+  end
+end

--- a/db/migrate/20210311125201_create_articles.rb
+++ b/db/migrate/20210311125201_create_articles.rb
@@ -1,0 +1,8 @@
+class CreateArticles < ActiveRecord::Migration[6.1]
+  def change
+    create_table :articles do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210311125241_create_photos.rb
+++ b/db/migrate/20210311125241_create_photos.rb
@@ -1,0 +1,8 @@
+class CreatePhotos < ActiveRecord::Migration[6.1]
+  def change
+    create_table :photos do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210311125252_create_audios.rb
+++ b/db/migrate/20210311125252_create_audios.rb
@@ -1,0 +1,8 @@
+class CreateAudios < ActiveRecord::Migration[6.1]
+  def change
+    create_table :audios do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210311125259_create_videos.rb
+++ b/db/migrate/20210311125259_create_videos.rb
@@ -1,0 +1,8 @@
+class CreateVideos < ActiveRecord::Migration[6.1]
+  def change
+    create_table :videos do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210311131056_change_data_type_of_type_in_contents.rb
+++ b/db/migrate/20210311131056_change_data_type_of_type_in_contents.rb
@@ -1,0 +1,6 @@
+class ChangeDataTypeOfTypeInContents < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :contents, :type
+    add_column :contents, :type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_11_124715) do
+ActiveRecord::Schema.define(version: 2021_03_11_131056) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -53,6 +53,16 @@ ActiveRecord::Schema.define(version: 2021_03_11_124715) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
+  create_table "articles", force: :cascade do |t|
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "audios", force: :cascade do |t|
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "contents", force: :cascade do |t|
     t.bigint "site_id", null: false
     t.bigint "user_id", null: false
@@ -61,7 +71,7 @@ ActiveRecord::Schema.define(version: 2021_03_11_124715) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.text "description"
-    t.integer "type"
+    t.string "type"
     t.index ["site_id"], name: "index_contents_on_site_id"
     t.index ["user_id"], name: "index_contents_on_user_id"
   end
@@ -79,6 +89,11 @@ ActiveRecord::Schema.define(version: 2021_03_11_124715) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["conversation_id"], name: "index_messages_on_conversation_id"
     t.index ["user_id"], name: "index_messages_on_user_id"
+  end
+
+  create_table "photos", force: :cascade do |t|
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "sites", force: :cascade do |t|
@@ -108,6 +123,11 @@ ActiveRecord::Schema.define(version: 2021_03_11_124715) do
     t.boolean "locatable", default: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  end
+
+  create_table "videos", force: :cascade do |t|
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_10_125411) do
+ActiveRecord::Schema.define(version: 2021_03_11_124715) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "action_text_rich_texts", force: :cascade do |t|
+    t.string "name", null: false
+    t.text "body"
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["record_type", "record_id", "name"], name: "index_action_text_rich_texts_uniqueness", unique: true
+  end
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -50,7 +60,8 @@ ActiveRecord::Schema.define(version: 2021_03_10_125411) do
     t.string "format"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.integer "category"
+    t.text "description"
+    t.integer "type"
     t.index ["site_id"], name: "index_contents_on_site_id"
     t.index ["user_id"], name: "index_contents_on_user_id"
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -77,31 +77,30 @@ puts "created #{Site.count} new sites"
 # CONTENT SEEDS
 # Without actual content or thumbnail images for now
 
-formats = %w[.txt .mp3 .mpg4]
 category = %w[article audio photo video]
 titles_text = %w[A\ brief\ history\ of 5\ things\ you\ should\ know\ about\  All\ you\ need\ to\ know\ about ]
 titles_audio = ["Get into the right mood with this Ottoman-style music", "The greatest Turkish songs of all time"]
 Site.all.each do |site|
   # text seeds
   titles_text.each do |title|
-    text = Content.new(title: "#{title} #{site.name}", category: category.first )
+    text = Article.new(title: "#{title} #{site.name}", category: category.first )
     text.site = site
     text.user = User.all.sample
     text.save!
   end
   # audio seeds
-  audio = Content.new(title: "Ten minute audioguide for #{site.name}", category: category.second)
+  audio = Audio.new(title: "Ten minute audioguide for #{site.name}", category: category.second)
   audio.site = site
   audio.user= User.all.sample
   audio.save!
   titles_audio.each do |title|
-    audio = Content.new(title: title, category: category.second)
+    audio = Audio.new(title: title, category: category.second)
     audio.site = site
     audio.user = User.all.sample
     audio.save!
   end
   # video seeds
-  video = Content.new(title: "Cool drone footage of #{site.name}", category: category.last)
+  video = Video.new(title: "Cool drone footage of #{site.name}", category: category.last)
   video.site = site
   video.user = User.all.sample
   video.save!

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -77,30 +77,30 @@ puts "created #{Site.count} new sites"
 # CONTENT SEEDS
 # Without actual content or thumbnail images for now
 
-category = %w[article audio photo video]
+type = %w[article audio photo video]
 titles_text = %w[A\ brief\ history\ of 5\ things\ you\ should\ know\ about\  All\ you\ need\ to\ know\ about ]
 titles_audio = ["Get into the right mood with this Ottoman-style music", "The greatest Turkish songs of all time"]
 Site.all.each do |site|
   # text seeds
   titles_text.each do |title|
-    text = Article.new(title: "#{title} #{site.name}", category: category.first )
+    text = Article.new(title: "#{title} #{site.name}" )
     text.site = site
     text.user = User.all.sample
     text.save!
   end
   # audio seeds
-  audio = Audio.new(title: "Ten minute audioguide for #{site.name}", category: category.second)
+  audio = Audio.new(title: "Ten minute audioguide for #{site.name}" )
   audio.site = site
   audio.user= User.all.sample
   audio.save!
   titles_audio.each do |title|
-    audio = Audio.new(title: title, category: category.second)
+    audio = Audio.new(title: title )
     audio.site = site
     audio.user = User.all.sample
     audio.save!
   end
   # video seeds
-  video = Video.new(title: "Cool drone footage of #{site.name}", category: category.last)
+  video = Video.new(title: "Cool drone footage of #{site.name}")
   video.site = site
   video.user = User.all.sample
   video.save!

--- a/test/models/article_test.rb
+++ b/test/models/article_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ArticleTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/audio_test.rb
+++ b/test/models/audio_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class AudioTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/photo_test.rb
+++ b/test/models/photo_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class PhotoTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/video_test.rb
+++ b/test/models/video_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class VideoTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Created 4 new models: Article, Photo, Audio and Video. These models all inherit from the same table: Content. They share the same title and description attributes and all `belong_to` a site and a user. What has also changed is that the Content `category`attribute no longer exists and has been replaced by `type`, which is a string, not an integer. When creating a new instance of Article, Photo, Audio or Video, you should not declare what `type`it is, because Rails takes care of that for us by looking at the name of model. So for example, Rails will automatically assign the type value `'article'` to an instance of Article when you create it. Let me know if anything is unclear.