### PR TITLE
Embed spotify feature

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,5 +1,5 @@
 class ArticlesController < ApplicationController
-  before_action :set_site, except: [:new, :create]
+  before_action :set_site, except: [:new, :create, :destroy]
 
   def index
     @site = Site.find(params[:site_id])
@@ -25,16 +25,16 @@ class ArticlesController < ApplicationController
     end
   end
 
-  private
-
-  def set_site
-    @site = Site.find(params[:site_id])
-  end
-  
   def destroy
     @article = Article.find(params[:id])
     @article.destroy
     redirect_to dashboard_path
+  end
+
+  private
+
+  def set_site
+    @site = Site.find(params[:site_id])
   end
 
   def article_params

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -16,12 +16,11 @@
           <% spotify_uri_type = split_uri.second %>
           <% spotify_uri_id = split_uri.last %>
           <% complete_url = "https://open.spotify.com/embed/#{spotify_uri_type}/#{spotify_uri_id}" %>
-          <iframe src=<% complete_url %> width="300" height="80" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>
-          <iframe src="https://open.spotify.com/embed/track/43sdRsmJFcSnlTWTVRhYtz" width="300" height="80" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>
+          <iframe src=<%= complete_url %> width="300" height="80" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>
         <% elsif content.type == 'Video' && content.url != nil %>
-          <% source_url = "https://www.youtube.com/embed/#{content.url}" %>
-          <iframe src=<% source_url %> height="150" width="200" frameborder="0"></iframe>
-          <iframe src="https://www.youtube.com/embed/UQcHyHoZ9Ys" height="150" width="200" frameborder="0" allowfullscreen></iframe>
+          <% match_data = content.url.match(/.*\/(.*)/) %>
+          <% source_url = "https://www.youtube.com/embed/#{match_data[1]}" %>
+          <iframe src=<%= source_url %> height="150" width="200" frameborder="0"></iframe>
         <% end %>
       </div>
       <% if content.type == 'Article' %>

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -20,7 +20,7 @@
         <% elsif content.type == 'Video' && content.url != nil %>
           <% match_data = content.url.match(/.*\/(.*)/) %>
           <% source_url = "https://www.youtube.com/embed/#{match_data[1]}" %>
-          <iframe src=<%= source_url %> height="150" width="200" frameborder="0"></iframe>
+          <iframe src=<%= source_url %> height="150" width="200" frameborder="0" allowfullscreen mozallowfullscreen></iframe>
         <% end %>
       </div>
       <% if content.type == 'Article' %>


### PR DESCRIPTION
Embedding feature is now working
Just to let you guys know, to add a youtube video, you need to paste in the link that Youtube gives you when you click on the 'share' button on the YT website. For a spotify track, you need to paste in the 'Spotify URI' link.
Still need to add the code to embed the video/audio on the site show page.
![image](https://user-images.githubusercontent.com/77265306/111139794-9ebf7900-8592-11eb-97e5-8faa6b4e80d3.png)
