### PR TITLE
Guard clauses in geolocation filters

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -12,12 +12,16 @@ class PagesController < ApplicationController
     elsif params["latitude"] && params["longitude"]
       @sites = Site.near([params["latitude"].to_f, params["longitude"].to_f], current_user.range)
     end
-    @site_markers = @sites.geocoded.map do |site|
-      {
-        lat: site.latitude,
-        lng: site.longitude,
-        infoWindow: render_to_string(partial: "info_window_sites", locals: { site: site })
-      }
+    if @sites.empty?
+      redirect_to root_path, notice: "There are no sites near you"
+    else
+      @site_markers = @sites.geocoded.map do |site|
+        {
+          lat: site.latitude,
+          lng: site.longitude,
+          infoWindow: render_to_string(partial: "info_window_sites", locals: { site: site })
+        }
+      end
     end
     @user_markers = @users.geocoded.map do |user|
       {

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -23,15 +23,18 @@
           <td><%= @user.location %></td>
         </tr>
         <tr>
+          <td>Range of near me filter</td>
+          <td><%= "#{@user.range} km" %></td>
+        </tr>
+        <tr>
           <td>Share your location?</td>
           <% if @user.locatable %>
             <td>Yes</td>
           <% else %>
             <td>No</td>
           <% end %>
-          <td>
-          </td>
         </tr>
+        <tr>
         <tr>
           <th colspan="2">Edit</th>
         </tr>


### PR DESCRIPTION
Prevents javascript code from breaking when the current location or geolocation of the user is such that there are no @sites.
When this is the case, the page refreshes and a flash error message appears.